### PR TITLE
Change VirtualBox NIC

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -149,6 +149,8 @@ Vagrant.configure("2") do |config|
         vb.cpus = vm_cpus i
         vb.customize ["modifyvm", :id, "--cpuexecutioncap", "#{$vb_cpuexecutioncap}"]
         config.ignition.config_obj = vb
+
+        vb.customize ['modifyvm', :id, '--nictype2', '82545EM']
       end
 
       ["vmware_fusion", "vmware_workstation"].each do |vmware|
@@ -166,7 +168,7 @@ Vagrant.configure("2") do |config|
       end
 
       ip = "172.17.8.#{i+100}"
-      config.vm.network :private_network, ip: ip
+      config.vm.network :private_network, ip: ip, adapter: "2"
       # This tells Ignition what the IP for eth1 (the host-only adapter) should be
       config.ignition.ip = ip
 


### PR DESCRIPTION
We've seen some instances of the kernel rebooting due
to a kenel paging request in the network RX code, coming
from the virtio_net module.  Switch the second nic, which
is the private network, to be an emulation of an Intel NIC,
avoiding the virtio_net code.

Only the second NIC is changed, the first NIC is left as
a virtio_net NIC.  That NIC is only used for host<->VM
communications, and changing it to an Intel NIC messes up
the NIC configuration, and leaving it as a virtio_net driver
keeps things working.  (The NIC order was getting changed,
causing CoreOS to configure the wrong interface for the
private network.)